### PR TITLE
Add Supabase support with agency/tenant views

### DIFF
--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -14,4 +14,4 @@
 - Clean and modern font for readability and professional look, focusing on clarity for property details.
 - Simple, geometric icons to represent amenities and features in a clear and concise manner.
 - Split screen layout for search results with property listings on one side and a dynamic map on the other. Card-based design for listings to showcase room details effectively.
-- Subtle hover effects on room cards and smooth transitions between reservation steps to enhance user engagement.
+- Subtle hover effects on room cards and smooth transitions between reservation steps to enhance user engagement.\n## Database\nUses Supabase to store room information accessible for agency and tenant versions.

--- a/env.example
+++ b/env.example
@@ -1,0 +1,4 @@
+# Supabase credentials
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "recharts": "^2.15.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.2"
+        "zod": "^3.24.2",
+        "@supabase/supabase-js": "^2.38.0"
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.12",
@@ -9876,6 +9877,11 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.38.0",
+      "resolved": "",
+      "integrity": ""
     },
     "node_modules/zod": {
       "version": "3.24.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "@supabase/supabase-js": "^2.38.0"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.12",

--- a/src/app/agency/page.tsx
+++ b/src/app/agency/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Room } from '@/lib/types';
+import { fetchRoomsFromSupabase } from '@/lib/supabaseRooms';
+
+export default function AgencyPage() {
+  const [rooms, setRooms] = useState<Room[]>([]);
+
+  useEffect(() => {
+    fetchRoomsFromSupabase().then(setRooms);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Listado de Habitaciones (Agencia)</h1>
+      <ul className="space-y-2">
+        {rooms.map(room => (
+          <li key={room.id} className="border p-2 rounded">
+            <Link href={`/room/${room.id}`}>{room.title ?? `Habitación ${room.id}`}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/tenant/page.tsx
+++ b/src/app/tenant/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import type { Room } from '@/lib/types';
+import { fetchRoomsFromSupabase } from '@/lib/supabaseRooms';
+
+export default function TenantPage() {
+  const [rooms, setRooms] = useState<Room[]>([]);
+
+  useEffect(() => {
+    fetchRoomsFromSupabase().then(setRooms);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Habitaciones Disponibles</h1>
+      <ul className="space-y-2">
+        {rooms.map(room => (
+          <li key={room.id} className="border p-2 rounded">
+            <Link href={`/room/${room.id}`}>{room.title ?? `Habitación ${room.id}`}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/src/lib/supabaseRooms.ts
+++ b/src/lib/supabaseRooms.ts
@@ -1,0 +1,20 @@
+import type { Room } from './types';
+import { supabase } from './supabaseClient';
+
+export async function fetchRoomsFromSupabase(): Promise<Room[]> {
+  const { data, error } = await supabase.from('rooms').select('*');
+  if (error) {
+    console.error('Error fetching rooms from Supabase', error.message);
+    return [];
+  }
+  return (data as Room[]) || [];
+}
+
+export async function fetchRoomByIdFromSupabase(id: number): Promise<Room | null> {
+  const { data, error } = await supabase.from('rooms').select('*').eq('id', id).maybeSingle();
+  if (error) {
+    console.error('Error fetching room from Supabase', error.message);
+    return null;
+  }
+  return data as Room | null;
+}


### PR DESCRIPTION
## Summary
- integrate Supabase client
- create helper to read rooms from Supabase
- add simple agency and tenant pages showing rooms
- provide example env file
- document that database uses Supabase

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684850e5a98c832d893e9f9b1751feb9